### PR TITLE
feat: add regex filter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
+    "test": "node --test",
     "dev": "node scripts/generate-chrome-locales.js && vite build --watch --mode development",
     "build": "npm run clean && node scripts/generate-chrome-locales.js && vite build",
     "build:dev": "node scripts/generate-chrome-locales.js && vite build --mode development",

--- a/src/utils/filterUtils.js
+++ b/src/utils/filterUtils.js
@@ -76,10 +76,14 @@ export const filterConnections = (connections, filters) => {
   }
 
   const regex = parseRegexFromFilter(text);
+  const matchesRegex = (value) => {
+    regex.lastIndex = 0;
+    return regex.test(value);
+  };
 
   return connections.filter((conn) => {
     if (regex) {
-      const matches = regex.test(conn.url) || regex.test(conn.id);
+      const matches = matchesRegex(conn.url) || matchesRegex(conn.id);
       return invert ? !matches : matches;
     }
 

--- a/src/utils/filterUtils.js
+++ b/src/utils/filterUtils.js
@@ -20,15 +20,24 @@ export const filterMessages = (messages, filters) => {
 
         // Text content filter
         if (text.trim()) {
-          const messageContent = msg.data.toLowerCase();
-          const filterText = text.toLowerCase();
-          const matchesText = messageContent.includes(filterText);
+          // If user provided a regex in the form /pattern/flags, use it.
+          // Otherwise, fall back to case-insensitive substring matching (previous behavior).
+          const regex = parseRegexFromFilter(text);
+          let matchesText;
+
+          if (regex) {
+            matchesText = regex.test(msg.data);
+          } else {
+            const messageContent = msg.data.toLowerCase();
+            const filterText = text.toLowerCase();
+            matchesText = messageContent.includes(filterText);
+          }
 
           // Apply invert logic
           if (invert) {
-            return !matchesText; // Show messages that DON'T contain the text
+            return !matchesText; // Show messages that DON'T contain the text / match the regex
           } else {
-            return matchesText; // Show messages that DO contain the text
+            return matchesText; // Show messages that DO contain the text / match the regex
           }
         }
 
@@ -66,13 +75,45 @@ export const filterConnections = (connections, filters) => {
     return connections;
   }
 
-  const filterText = text.toLowerCase();
+  const regex = parseRegexFromFilter(text);
 
   return connections.filter((conn) => {
+    if (regex) {
+      const matches = regex.test(conn.url) || regex.test(conn.id);
+      return invert ? !matches : matches;
+    }
+
+    const filterText = text.toLowerCase();
     const urlMatches = conn.url.toLowerCase().includes(filterText);
     const idMatches = conn.id.toLowerCase().includes(filterText);
     const matches = urlMatches || idMatches;
 
     return invert ? !matches : matches;
   });
+};
+
+/**
+ * Try to parse a regex from a filter string using the form /pattern/flags.
+ * If parsing fails or the string isn't in regex form, returns null.
+ * If no flags are provided, defaults to case-insensitive ("i") to preserve previous behavior.
+ * @param {string} text
+ * @returns {RegExp|null}
+ */
+const parseRegexFromFilter = (text) => {
+  if (!text || !text.startsWith("/")) return null;
+  const lastSlash = text.lastIndexOf("/");
+  if (lastSlash === 0) return null; // no pattern
+
+  const pattern = text.slice(1, lastSlash);
+  let flags = text.slice(lastSlash + 1);
+
+  // Default to case-insensitive if the user did not provide any flags
+  if (!flags) flags = "i";
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch (e) {
+    // Invalid regex — fall back to substring matching
+    return null;
+  }
 };

--- a/test/filterUtils.test.js
+++ b/test/filterUtils.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterConnections,
+  filterMessages,
+} from "../src/utils/filterUtils.js";
+
+test("filters messages with a regular expression", () => {
+  const messages = [
+    { data: "hello websocket", direction: "incoming", timestamp: 1 },
+    { data: "plain text", direction: "incoming", timestamp: 2 },
+  ];
+
+  const result = filterMessages(messages, { text: "/websocket/i" });
+
+  assert.deepEqual(result, [messages[0]]);
+});
+
+test("evaluates a global regular expression independently for every connection", () => {
+  const connections = [
+    { id: "first", url: "wss://example.test/socket" },
+    { id: "second", url: "wss://example.test/socket" },
+  ];
+
+  const result = filterConnections(connections, { text: "/example/g" });
+
+  assert.deepEqual(result, connections);
+});
+
+test("evaluates a sticky regular expression independently for every connection", () => {
+  const connections = [
+    { id: "first", url: "wss://example.test/socket" },
+    { id: "second", url: "wss://example.test/socket" },
+  ];
+
+  const result = filterConnections(connections, { text: "/wss/y" });
+
+  assert.deepEqual(result, connections);
+});


### PR DESCRIPTION
add regex filter support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regex support to text filters for messages and connections using /pattern/flags, while preserving previous case-insensitive substring behavior when not using regex or when the regex is invalid. Global and sticky regexes are evaluated independently per connection to avoid state leaks.

- Accepts /pattern/flags in filterMessages and filterConnections; matches message data, connection URL, and ID.
- Defaults to the "i" flag when no flags are provided; invalid regex falls back to substring matching.
- For connections, resets regex state (`lastIndex`) before each test so g/y flags don’t carry over; invert filtering still works with regex.
- Adds tests for regex cases and a `test` npm script.

<sup>Written for commit e58daebb3bf900e2119b626f5dcacc54b5337d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

