### PR TITLE
feat: add JSON viewer keyword search and switchable message split layout

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -723,6 +723,10 @@
     "message": "Copy",
     "description": "Translation for jsonViewer.tooltips.copy"
   },
+  "jsonViewer_tooltips_search": {
+    "message": "Search (Ctrl+F)",
+    "description": "Translation for jsonViewer.tooltips.search"
+  },
   "jsonViewer_tooltips_copied": {
     "message": "Copied!",
     "description": "Translation for jsonViewer.tooltips.copied"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -795,6 +795,14 @@
     "message": "Clear all messages",
     "description": "Translation for messageDetails.controls.clearMessages"
   },
+  "messageDetails_controls_horizontalLayout": {
+    "message": "Switch to left/right layout",
+    "description": "Translation for messageDetails.controls.horizontalLayout"
+  },
+  "messageDetails_controls_verticalLayout": {
+    "message": "Switch to top/bottom layout",
+    "description": "Translation for messageDetails.controls.verticalLayout"
+  },
   "messageDetails_table_data": {
     "message": "Data",
     "description": "Translation for messageDetails.table.data"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -795,6 +795,14 @@
     "message": "清空所有消息",
     "description": "Translation for messageDetails.controls.clearMessages"
   },
+  "messageDetails_controls_horizontalLayout": {
+    "message": "切换为左右布局",
+    "description": "Translation for messageDetails.controls.horizontalLayout"
+  },
+  "messageDetails_controls_verticalLayout": {
+    "message": "切换为上下布局",
+    "description": "Translation for messageDetails.controls.verticalLayout"
+  },
   "messageDetails_table_data": {
     "message": "数据",
     "description": "Translation for messageDetails.table.data"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -723,6 +723,10 @@
     "message": "复制",
     "description": "Translation for jsonViewer.tooltips.copy"
   },
+  "jsonViewer_tooltips_search": {
+    "message": "搜索 (Ctrl+F)",
+    "description": "Translation for jsonViewer.tooltips.search"
+  },
   "jsonViewer_tooltips_copied": {
     "message": "已复制！",
     "description": "Translation for jsonViewer.tooltips.copied"

--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -183,7 +183,7 @@
   "jsonViewer.tooltips.nestedParseJson": "Verschachteltes JSON analysieren",
   "jsonViewer.tooltips.noNestedData": "Keine verschachtelten JSON-Daten gefunden",
   "jsonViewer.tooltips.copy": "Kopieren",
-  "jsonViewer.tooltips.search": "Suchen (Strg+F)",
+  "jsonViewer.tooltips.search": "Suchen (Strg/Cmd + F)",
   "jsonViewer.tooltips.copied": "Kopiert!",
   "jsonViewer.tooltips.addToFavorites": "Zu Favoriten hinzufügen",
   "jsonViewer.tooltips.simulate": "Diese Nachricht simulieren",

--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -201,6 +201,8 @@
   "messageDetails.controls.invert": "Umkehren",
   "messageDetails.controls.filterPlaceholder": "Nachrichten nach Textinhalt filtern",
   "messageDetails.controls.clearMessages": "Alle Nachrichten löschen",
+  "messageDetails.controls.horizontalLayout": "Zu Links-/Rechts-Layout wechseln",
+  "messageDetails.controls.verticalLayout": "Zu Oben-/Unten-Layout wechseln",
   "messageDetails.table.data": "Daten",
   "messageDetails.table.length": "Länge",
   "messageDetails.table.time": "Zeit",

--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -183,6 +183,7 @@
   "jsonViewer.tooltips.nestedParseJson": "Verschachteltes JSON analysieren",
   "jsonViewer.tooltips.noNestedData": "Keine verschachtelten JSON-Daten gefunden",
   "jsonViewer.tooltips.copy": "Kopieren",
+  "jsonViewer.tooltips.search": "Suchen (Strg+F)",
   "jsonViewer.tooltips.copied": "Kopiert!",
   "jsonViewer.tooltips.addToFavorites": "Zu Favoriten hinzufügen",
   "jsonViewer.tooltips.simulate": "Diese Nachricht simulieren",

--- a/src/assets/locales/en-us.json
+++ b/src/assets/locales/en-us.json
@@ -180,6 +180,7 @@
   "jsonViewer.tooltips.nestedParseJson": "Nested Parse JSON",
   "jsonViewer.tooltips.noNestedData": "No nested JSON data found",
   "jsonViewer.tooltips.copy": "Copy",
+  "jsonViewer.tooltips.search": "Search (Ctrl+F)",
   "jsonViewer.tooltips.copied": "Copied!",
   "jsonViewer.tooltips.addToFavorites": "Add to Favorites",
   "jsonViewer.tooltips.simulate": "Simulate this message",

--- a/src/assets/locales/en-us.json
+++ b/src/assets/locales/en-us.json
@@ -198,6 +198,8 @@
   "messageDetails.controls.invert": "Invert",
   "messageDetails.controls.filterPlaceholder": "Filter messages by text content",
   "messageDetails.controls.clearMessages": "Clear all messages",
+  "messageDetails.controls.horizontalLayout": "Switch to left/right layout",
+  "messageDetails.controls.verticalLayout": "Switch to top/bottom layout",
   "messageDetails.table.data": "Data",
   "messageDetails.table.length": "Length",
   "messageDetails.table.time": "Time",

--- a/src/assets/locales/en-us.json
+++ b/src/assets/locales/en-us.json
@@ -180,7 +180,7 @@
   "jsonViewer.tooltips.nestedParseJson": "Nested Parse JSON",
   "jsonViewer.tooltips.noNestedData": "No nested JSON data found",
   "jsonViewer.tooltips.copy": "Copy",
-  "jsonViewer.tooltips.search": "Search (Ctrl+F)",
+  "jsonViewer.tooltips.search": "Search (Ctrl / Cmd + F)",
   "jsonViewer.tooltips.copied": "Copied!",
   "jsonViewer.tooltips.addToFavorites": "Add to Favorites",
   "jsonViewer.tooltips.simulate": "Simulate this message",

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -202,6 +202,8 @@
   "messageDetails.controls.invert": "Inverser",
   "messageDetails.controls.filterPlaceholder": "Filtrer les messages par contenu textuel",
   "messageDetails.controls.clearMessages": "Effacer tous les messages",
+  "messageDetails.controls.horizontalLayout": "Passer en disposition gauche/droite",
+  "messageDetails.controls.verticalLayout": "Passer en disposition haut/bas",
   "messageDetails.table.data": "Données",
   "messageDetails.table.length": "Longueur",
   "messageDetails.table.time": "Heure",

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -184,6 +184,7 @@
   "jsonViewer.tooltips.nestedParseJson": "Analyser le JSON imbriqué",
   "jsonViewer.tooltips.noNestedData": "Aucune donnée JSON imbriquée trouvée",
   "jsonViewer.tooltips.copy": "Copier",
+  "jsonViewer.tooltips.search": "Rechercher (Ctrl+F)",
   "jsonViewer.tooltips.copied": "Copié !",
   "jsonViewer.tooltips.addToFavorites": "Ajouter aux favoris",
   "jsonViewer.tooltips.simulate": "Simuler ce message",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -182,6 +182,7 @@
   "jsonViewer.tooltips.nestedParseJson": "ネストしたJSONを解析",
   "jsonViewer.tooltips.noNestedData": "ネストしたJSONデータが見つかりません",
   "jsonViewer.tooltips.copy": "コピー",
+  "jsonViewer.tooltips.search": "検索 (Ctrl+F)",
   "jsonViewer.tooltips.copied": "コピーしました！",
   "jsonViewer.tooltips.addToFavorites": "お気に入りに追加",
   "jsonViewer.tooltips.simulate": "このメッセージをシミュレート",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -200,6 +200,8 @@
   "messageDetails.controls.invert": "反転",
   "messageDetails.controls.filterPlaceholder": "テキスト内容でメッセージをフィルター",
   "messageDetails.controls.clearMessages": "全てのメッセージをクリア",
+  "messageDetails.controls.horizontalLayout": "左右レイアウトに切り替え",
+  "messageDetails.controls.verticalLayout": "上下レイアウトに切り替え",
   "messageDetails.table.data": "データ",
   "messageDetails.table.length": "長さ",
   "messageDetails.table.time": "時刻",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -185,6 +185,7 @@
   "jsonViewer.tooltips.nestedParseJson": "중첩된 JSON 파싱",
   "jsonViewer.tooltips.noNestedData": "중첩된 JSON 데이터를 찾을 수 없습니다",
   "jsonViewer.tooltips.copy": "복사",
+  "jsonViewer.tooltips.search": "검색 (Ctrl+F)",
   "jsonViewer.tooltips.copied": "복사됨!",
   "jsonViewer.tooltips.addToFavorites": "즐겨찾기에 추가",
   "jsonViewer.tooltips.simulate": "이 메시지 시뮬레이션",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -203,6 +203,8 @@
   "messageDetails.controls.invert": "반전",
   "messageDetails.controls.filterPlaceholder": "텍스트 내용으로 메시지 필터링",
   "messageDetails.controls.clearMessages": "모든 메시지 지우기",
+  "messageDetails.controls.horizontalLayout": "좌우 레이아웃으로 전환",
+  "messageDetails.controls.verticalLayout": "상하 레이아웃으로 전환",
   "messageDetails.table.data": "데이터",
   "messageDetails.table.length": "길이",
   "messageDetails.table.time": "시간",

--- a/src/assets/locales/zh-cn.json
+++ b/src/assets/locales/zh-cn.json
@@ -198,6 +198,8 @@
   "messageDetails.controls.invert": "反向",
   "messageDetails.controls.filterPlaceholder": "按文本内容筛选消息",
   "messageDetails.controls.clearMessages": "清空所有消息",
+  "messageDetails.controls.horizontalLayout": "切换为左右布局",
+  "messageDetails.controls.verticalLayout": "切换为上下布局",
   "messageDetails.table.data": "数据",
   "messageDetails.table.length": "长度",
   "messageDetails.table.time": "时间",

--- a/src/assets/locales/zh-cn.json
+++ b/src/assets/locales/zh-cn.json
@@ -180,6 +180,7 @@
   "jsonViewer.tooltips.nestedParseJson": "嵌套解析 JSON",
   "jsonViewer.tooltips.noNestedData": "未发现嵌套 JSON 数据",
   "jsonViewer.tooltips.copy": "复制",
+  "jsonViewer.tooltips.search": "搜索 (Ctrl+F)",
   "jsonViewer.tooltips.copied": "已复制！",
   "jsonViewer.tooltips.addToFavorites": "添加到收藏",
   "jsonViewer.tooltips.simulate": "模拟此消息",

--- a/src/assets/locales/zh-tw.json
+++ b/src/assets/locales/zh-tw.json
@@ -199,6 +199,8 @@
   "messageDetails.controls.invert": "反向",
   "messageDetails.controls.filterPlaceholder": "按文字內容篩選訊息",
   "messageDetails.controls.clearMessages": "清空所有訊息",
+  "messageDetails.controls.horizontalLayout": "切換為左右佈局",
+  "messageDetails.controls.verticalLayout": "切換為上下佈局",
   "messageDetails.table.data": "資料",
   "messageDetails.table.length": "長度",
   "messageDetails.table.time": "時間",

--- a/src/assets/locales/zh-tw.json
+++ b/src/assets/locales/zh-tw.json
@@ -181,6 +181,7 @@
   "jsonViewer.tooltips.nestedParseJson": "巢狀解析 JSON",
   "jsonViewer.tooltips.noNestedData": "未發現巢狀 JSON 資料",
   "jsonViewer.tooltips.copy": "複製",
+  "jsonViewer.tooltips.search": "搜尋 (Ctrl+F)",
   "jsonViewer.tooltips.copied": "已複製！",
   "jsonViewer.tooltips.addToFavorites": "新增到收藏",
   "jsonViewer.tooltips.simulate": "模擬此訊息",

--- a/src/components/JsonViewer.jsx
+++ b/src/components/JsonViewer.jsx
@@ -473,7 +473,10 @@ const JsonViewer = ({
   useEffect(() => {
     const handleKeyDown = (e) => {
       const isFindShortcut =
-        (e.ctrlKey || e.metaKey) && !e.altKey && (e.key === "f" || e.key === "F");
+        (e.ctrlKey || e.metaKey) &&
+        !e.altKey &&
+        !e.shiftKey &&
+        e.key.toLowerCase() === "f";
       if (!isFindShortcut) return;
 
       const root = rootRef.current;

--- a/src/components/JsonViewer.jsx
+++ b/src/components/JsonViewer.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { EditorView } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
+import { search, openSearchPanel } from "@codemirror/search";
 import Protobuf from "../Icons/Protobuf";
 
 const deepEqual = (a, b) => {
@@ -36,7 +37,8 @@ import {
   Send,
   Layers2,
   Check,
-  Info
+  Info,
+  Search
 } from "lucide-react";
 import { t } from "../utils/i18n.js";
 import "../styles/JsonViewer.css";
@@ -453,9 +455,46 @@ const JsonViewer = ({
 
   const content = getDisplayContent();
 
+  // References for programmatic actions (search) and focus-scoped shortcut handling
+  const cmRef = useRef(null);
+  const rootRef = useRef(null);
+
+  // Open CodeMirror's native search panel (also reachable via Ctrl/Cmd+F)
+  const handleOpenSearch = useCallback(() => {
+    const view = cmRef.current?.view;
+    if (view) {
+      openSearchPanel(view);
+      view.focus();
+    }
+  }, []);
+
+  // Intercept Ctrl/Cmd+F when focus is inside this viewer so the CodeMirror
+  // search panel opens instead of the browser's native find bar.
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      const isFindShortcut =
+        (e.ctrlKey || e.metaKey) && !e.altKey && (e.key === "f" || e.key === "F");
+      if (!isFindShortcut) return;
+
+      const root = rootRef.current;
+      const view = cmRef.current?.view;
+      if (!root || !view) return;
+
+      if (root.contains(document.activeElement)) {
+        e.preventDefault();
+        e.stopPropagation();
+        openSearchPanel(view);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
+
   // CodeMirror extensions configuration
   const extensions = [
     isValidJson ? json() : [],
+    search({ top: true }),
     EditorView.theme({
       "&": {
         fontSize: "12px",
@@ -493,12 +532,13 @@ const JsonViewer = ({
       },
     }),
     textWrap ? EditorView.lineWrapping : [],
-    EditorView.editable.of(!readOnly),
+    // Keep the view focusable even when read-only so it can hold a cursor and
+    // Ctrl/Cmd+F search + text selection work; EditorState.readOnly blocks edits.
     EditorState.readOnly.of(readOnly),
   ].filter(Boolean);
 
   return (
-    <div className={`json-viewer ${className}`}>
+    <div className={`json-viewer ${className}`} ref={rootRef}>
       {showControls && (
         <div className="json-viewer-controls">
           <div className="json-viewer-controls-left">
@@ -586,6 +626,15 @@ const JsonViewer = ({
           <div className="json-viewer-controls-right">
             {/* Action buttons */}
             <div className="json-viewer-action-buttons">
+              {/* Search button - opens CodeMirror native search panel */}
+              <button
+                onClick={handleOpenSearch}
+                className="json-viewer-btn btn-search json-viewer-btn-inactive"
+                title={t("jsonViewer.tooltips.search") || "Search (Ctrl+F)"}
+              >
+                <Search size={14} />
+              </button>
+
               {/* Simulate button */}
               {onSimulate && (
                 <button
@@ -657,6 +706,7 @@ const JsonViewer = ({
 
       <div className="json-viewer-container">
         <CodeMirror
+          ref={cmRef}
           value={content}
           onChange={handleChange}
           extensions={extensions}

--- a/src/components/MessageDetails.jsx
+++ b/src/components/MessageDetails.jsx
@@ -443,7 +443,7 @@ const MessageDetails = ({
   return (
     <div className="message-details">
       <div className="messages-container">
-        <PanelGroup key={layoutDirection} direction={layoutDirection}>
+        <PanelGroup direction={layoutDirection}>
           <Panel
             defaultSize={
               selectedMessageKey ? (isHorizontal ? 55 : 70) : 100

--- a/src/components/MessageDetails.jsx
+++ b/src/components/MessageDetails.jsx
@@ -423,6 +423,10 @@ const MessageDetails = ({
 
   const isHorizontal = layoutDirection === "horizontal";
 
+  // Resolve the selected message within the currently visible (filtered) list.
+  // When the active filter hides it, this is null and the detail panel must stay closed.
+  const selectedMessage = getSelectedMessage();
+
   // Detail panel visual style adapts to split direction (shadow/rounded corners face the list)
   const detailPanelStyle = isHorizontal
     ? {
@@ -446,7 +450,7 @@ const MessageDetails = ({
         <PanelGroup direction={layoutDirection}>
           <Panel
             defaultSize={
-              selectedMessageKey ? (isHorizontal ? 55 : 70) : 100
+              selectedMessage ? (isHorizontal ? 55 : 70) : 100
             }
             minSize={5}
           >
@@ -564,7 +568,7 @@ const MessageDetails = ({
             </div>
           </Panel>
 
-          {selectedMessageKey && (
+          {selectedMessage && (
               <>
                 <PanelResizeHandle className={resizeHandleClass} />
                 <Panel
@@ -576,9 +580,6 @@ const MessageDetails = ({
                   <div className="message-detail-simple" key={selectedConnectionId}>
                     <div className="detail-content">
                       {(() => {
-                        const selectedMessage = getSelectedMessage();
-                        if (!selectedMessage) return null;
-
                         const messageKey = selectedMessageKey;
                         return (
                           // <div className="detail-body">

--- a/src/components/MessageDetails.jsx
+++ b/src/components/MessageDetails.jsx
@@ -4,7 +4,7 @@ import { filterMessages } from "../utils/filterUtils";
 import JsonViewer from "./JsonViewer";
 import useNewMessageHighlight from "../hooks/useNewMessageHighlight";
 import { addFromMessageList } from "../utils/globalFavorites";
-import { Ban, Search, Settings, CircleX } from "lucide-react";
+import { Ban, Search, Settings, CircleX, Columns2, Rows2 } from "lucide-react";
 import { t } from "../utils/i18n.js";
 import CheeseIcon from "../Icons/cheese.jsx";
 import ProtobufIcon from "../Icons/Protobuf.jsx";
@@ -76,6 +76,16 @@ const MessageDetails = ({
   const [copiedMessageKey, setCopiedMessageKey] = useState(null); // Copied message key
   const [sortOrder, setSortOrder] = useState("desc"); // 'asc' | 'desc' time sorting
   const [hoveredMessageKey, setHoveredMessageKey] = useState(null); // Hovered message key
+  // Split layout direction: 'vertical' (list on top, detail below) | 'horizontal' (list left, detail right)
+  const [layoutDirection, setLayoutDirection] = useState(() => {
+    try {
+      return localStorage.getItem("websocket-message-layout") === "horizontal"
+        ? "horizontal"
+        : "vertical";
+    } catch {
+      return "vertical";
+    }
+  });
 
   
   // Use new message highlight hook
@@ -213,6 +223,19 @@ const MessageDetails = ({
 
   const handleSortToggle = () => {
     setSortOrder(sortOrder === "desc" ? "asc" : "desc");
+  };
+
+  // Toggle between vertical (top/bottom) and horizontal (left/right) split layout
+  const handleToggleLayout = () => {
+    setLayoutDirection((prev) => {
+      const next = prev === "vertical" ? "horizontal" : "vertical";
+      try {
+        localStorage.setItem("websocket-message-layout", next);
+      } catch {
+        // ignore persistence failures (e.g. storage disabled)
+      }
+      return next;
+    });
   };
 
   const truncateMessage = (message, maxLength = 120) => {
@@ -398,70 +421,106 @@ const MessageDetails = ({
     );
   };
 
+  const isHorizontal = layoutDirection === "horizontal";
+
+  // Detail panel visual style adapts to split direction (shadow/rounded corners face the list)
+  const detailPanelStyle = isHorizontal
+    ? {
+        boxShadow: "rgba(21, 21, 21, 0.81) -5px 0px 20px 20px",
+        borderTopLeftRadius: "20px",
+        borderBottomLeftRadius: "20px",
+      }
+    : {
+        boxShadow: "rgba(21, 21, 21, 0.81) 0px -5px 20px 20px",
+        borderTopLeftRadius: "20px",
+        borderTopRightRadius: "20px",
+      };
+
+  const resizeHandleClass = `panel-resize-handle ${
+    isHorizontal ? "vertical" : "horizontal"
+  } message-detail-resize-handle`;
+
   return (
     <div className="message-details">
-      <div className="details-header">
-        <div className="connection-info">
-          <span className="connection-badge" title={connection.url}>{connection.url}</span>
-        </div>
-        <div className="controls">
-          <div className="control-row">
-            <div className="filter-controls direction-filter">
-              <select value={filterDirection} onChange={(e) => setFilterDirection(e.target.value)}>
-                <option value="all">{t("messageDetails.controls.all")}</option>
-                <option value="outgoing">{t("messageDetails.controls.send")}</option>
-                <option value="incoming">{t("messageDetails.controls.receive")}</option>
-              </select>
-            </div>
-            <div className="filter-controls search-filter">
-              <div className="filter-input-container">
-                <span className="filter-icon">
-                  <Search size={12} />
-                </span>
-                <input
-                  type="text"
-                  value={filterText}
-                  onChange={(e) => setFilterText(e.target.value)}
-                  placeholder={t("messageDetails.controls.filterPlaceholder")}
-                />
-                {filterText && (
-                  <button className="clear-filter-btn" onClick={handleClearSearchFilter}>
-                    <CircleX size={12} />
-                  </button>
-                )}
-              </div>
-            </div>
-            <label className="invert-checkbox">
-              <input type="checkbox" checked={filterInvert} onChange={(e) => setFilterInvert(e.target.checked)} />
-              <span className="checkmark"></span>
-              <span className="checkbox-label">{t("messageDetails.controls.invert")}</span>
-            </label>
-            <button
-              className="clear-messages-btn"
-              onClick={handleClearMessagesList}
-              disabled={!connection || !connection.messages || connection.messages.length === 0}
-              title={t("messageDetails.controls.clearMessages")}
-            >
-              <Ban size={14} />
-            </button>
-          </div>
-        </div>
-      </div>
-
       <div className="messages-container">
-        {sortedMessages.length === 0 ? (
-          <div className="empty-state">
-            <p>{t("messageDetails.emptyState.noMessages")}</p>
-          </div>
-        ) : (
-          <PanelGroup direction="vertical">
-            <Panel defaultSize={selectedMessageKey ? 70 : 100} minSize={5}>
-              <div 
-                className="messages-table-container" 
-                tabIndex={0}
-                style={{ outline: 'none' }}
-              >
-                <table className="ws-messages-table">
+        <PanelGroup key={layoutDirection} direction={layoutDirection}>
+          <Panel
+            defaultSize={
+              selectedMessageKey ? (isHorizontal ? 55 : 70) : 100
+            }
+            minSize={5}
+          >
+            <div className="message-list-pane">
+              <div className="details-header">
+                <div className="connection-info">
+                  <span className="connection-badge" title={connection.url}>{connection.url}</span>
+                </div>
+                <div className="controls">
+                  <div className="control-row">
+                    <div className="filter-controls direction-filter">
+                      <select value={filterDirection} onChange={(e) => setFilterDirection(e.target.value)}>
+                        <option value="all">{t("messageDetails.controls.all")}</option>
+                        <option value="outgoing">{t("messageDetails.controls.send")}</option>
+                        <option value="incoming">{t("messageDetails.controls.receive")}</option>
+                      </select>
+                    </div>
+                    <div className="filter-controls search-filter">
+                      <div className="filter-input-container">
+                        <span className="filter-icon">
+                          <Search size={12} />
+                        </span>
+                        <input
+                          type="text"
+                          value={filterText}
+                          onChange={(e) => setFilterText(e.target.value)}
+                          placeholder={t("messageDetails.controls.filterPlaceholder")}
+                        />
+                        {filterText && (
+                          <button className="clear-filter-btn" onClick={handleClearSearchFilter}>
+                            <CircleX size={12} />
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    <label className="invert-checkbox">
+                      <input type="checkbox" checked={filterInvert} onChange={(e) => setFilterInvert(e.target.checked)} />
+                      <span className="checkmark"></span>
+                      <span className="checkbox-label">{t("messageDetails.controls.invert")}</span>
+                    </label>
+                    <button
+                      className="layout-toggle-btn"
+                      onClick={handleToggleLayout}
+                      title={
+                        isHorizontal
+                          ? t("messageDetails.controls.verticalLayout")
+                          : t("messageDetails.controls.horizontalLayout")
+                      }
+                    >
+                      {isHorizontal ? <Rows2 size={14} /> : <Columns2 size={14} />}
+                    </button>
+                    <button
+                      className="clear-messages-btn"
+                      onClick={handleClearMessagesList}
+                      disabled={!connection || !connection.messages || connection.messages.length === 0}
+                      title={t("messageDetails.controls.clearMessages")}
+                    >
+                      <Ban size={14} />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              {sortedMessages.length === 0 ? (
+                <div className="empty-state">
+                  <p>{t("messageDetails.emptyState.noMessages")}</p>
+                </div>
+              ) : (
+                <div
+                  className="messages-table-container"
+                  tabIndex={0}
+                  style={{ outline: 'none' }}
+                >
+                  <table className="ws-messages-table">
                   <thead>
                     <tr>
                       <th className="col-data">{t("messageDetails.table.data")}</th>
@@ -499,22 +558,20 @@ const MessageDetails = ({
                       );
                     })}
                   </tbody>
-                </table>
-              </div>
-            </Panel>
+                    </table>
+                  </div>
+                )}
+            </div>
+          </Panel>
 
-            {selectedMessageKey && (
+          {selectedMessageKey && (
               <>
-                <PanelResizeHandle className="panel-resize-handle horizontal message-detail-resize-handle" />
+                <PanelResizeHandle className={resizeHandleClass} />
                 <Panel
-                  defaultSize={50}
+                  defaultSize={isHorizontal ? 45 : 50}
                   minSize={10}
                   maxSize={95}
-                  style={{
-                    boxShadow: "rgba(21, 21, 21, 0.81) 0px -5px 20px 20px",
-                    borderTopLeftRadius: "20px",
-                    borderTopRightRadius: "20px",
-                  }}
+                  style={detailPanelStyle}
                 >
                   <div className="message-detail-simple" key={selectedConnectionId}>
                     <div className="detail-content">
@@ -570,8 +627,7 @@ const MessageDetails = ({
                 </Panel>
               </>
             )}
-          </PanelGroup>
-        )}
+        </PanelGroup>
       </div>
     </div>
   );

--- a/src/styles/JsonViewer.css
+++ b/src/styles/JsonViewer.css
@@ -120,6 +120,15 @@
   stroke: #c4b5fd;
 }
 
+.json-viewer-action-buttons .json-viewer-btn.btn-search:hover {
+  background: #172a3a;
+  color: #60a5fa;
+}
+.json-viewer-action-buttons .json-viewer-btn.btn-search:hover svg {
+  color: #60a5fa;
+  stroke: #60a5fa;
+}
+
 /* Animated buttons that appear on first simulate click in JsonViewer */
 .json-viewer-animated-buttons {
   display: flex;
@@ -613,4 +622,86 @@
 .json-viewer-codemirror .cm-searchMatch-selected {
   background-color: rgba(255, 193, 7, 0.6);
   border: 1px solid rgba(255, 193, 7, 0.9);
+}
+
+/* Native search panel (opened via toolbar button or Ctrl/Cmd+F) */
+.json-viewer-codemirror .cm-panels {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.json-viewer-codemirror .cm-panels.cm-panels-top {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.json-viewer-codemirror .cm-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 32px 6px 8px;
+  font-size: 12px;
+}
+
+.json-viewer-codemirror .cm-search .cm-textfield {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 3px 6px;
+  font-size: 12px;
+  outline: none;
+}
+
+.json-viewer-codemirror .cm-search .cm-textfield:focus {
+  border-color: var(--accent-color);
+}
+
+.json-viewer-codemirror .cm-search .cm-button {
+  background: var(--bg-tertiary);
+  background-image: none;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 3px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.json-viewer-codemirror .cm-search .cm-button:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border-color: var(--accent-color);
+}
+
+.json-viewer-codemirror .cm-search label {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.json-viewer-codemirror .cm-panel.cm-search [name="close"] {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.json-viewer-codemirror .cm-panel.cm-search [name="close"]:hover {
+  color: var(--danger-color);
 }

--- a/src/styles/MessageDetails.css
+++ b/src/styles/MessageDetails.css
@@ -1074,3 +1074,68 @@
   box-shadow: 0px 1px 7px 4px rgb(0 0 0 / 21%);
   pointer-events: none;
 }
+
+/* Left/right split: list pane wraps header + table, detail sits in a side panel */
+.message-list-pane {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.message-list-pane .messages-table-container {
+  flex: 1;
+  min-height: 0;
+  height: auto;
+}
+
+.message-list-pane .empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Layout direction toggle button in the header controls */
+.layout-toggle-btn {
+  padding: 2px 3px;
+  border: none;
+  border-radius: 2px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  height: 20px;
+  min-width: 20px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.layout-toggle-btn:hover {
+  background-color: var(--bg-secondary);
+  color: var(--accent-color);
+}
+
+/* Vertical divider used when the detail panel is placed on the right side */
+.message-detail-resize-handle.panel-resize-handle.vertical {
+  background-color: rgba(255, 255, 255, 0.3);
+  transition: background-color 0.2s;
+  box-shadow: rgb(0 0 0 / 88%) -8px 0px 13px 1px;
+  position: relative;
+}
+
+.message-detail-resize-handle.panel-resize-handle.vertical::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -5px;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 24px;
+  background-color: rgba(255, 255, 255, 0.838);
+  opacity: 0.7;
+  box-shadow: 1px 0px 7px 4px rgb(0 0 0 / 21%);
+  pointer-events: none;
+}

--- a/src/utils/i18n-key-mapping.json
+++ b/src/utils/i18n-key-mapping.json
@@ -180,6 +180,7 @@
   "jsonViewer_tooltips_nestedParseJson": "jsonViewer.tooltips.nestedParseJson",
   "jsonViewer_tooltips_noNestedData": "jsonViewer.tooltips.noNestedData",
   "jsonViewer_tooltips_copy": "jsonViewer.tooltips.copy",
+  "jsonViewer_tooltips_search": "jsonViewer.tooltips.search",
   "jsonViewer_tooltips_copied": "jsonViewer.tooltips.copied",
   "jsonViewer_tooltips_addToFavorites": "jsonViewer.tooltips.addToFavorites",
   "jsonViewer_tooltips_simulate": "jsonViewer.tooltips.simulate",

--- a/src/utils/i18n-key-mapping.json
+++ b/src/utils/i18n-key-mapping.json
@@ -198,6 +198,8 @@
   "messageDetails_controls_invert": "messageDetails.controls.invert",
   "messageDetails_controls_filterPlaceholder": "messageDetails.controls.filterPlaceholder",
   "messageDetails_controls_clearMessages": "messageDetails.controls.clearMessages",
+  "messageDetails_controls_horizontalLayout": "messageDetails.controls.horizontalLayout",
+  "messageDetails_controls_verticalLayout": "messageDetails.controls.verticalLayout",
   "messageDetails_table_data": "messageDetails.table.data",
   "messageDetails_table_length": "messageDetails.table.length",
   "messageDetails_table_time": "messageDetails.table.time",


### PR DESCRIPTION
This PR bundles two independent UX improvements for the DevTools panel:

1. **In-editor keyword search for the JSON viewer** — search within message payloads without leaving the panel.
2. **Switchable horizontal/vertical split layout for Message Details** — choose between a top/bottom or left/right arrangement, with the preference persisted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-editor search to the JSON viewer and a switchable horizontal/vertical split for Message Details. Improves inspection and keeps layout and view state intact across sessions and layout toggles.

- New Features
  - JSON viewer search: Opens CodeMirror’s panel via toolbar or Ctrl/Cmd+F using `@codemirror/search`; scoped to the viewer; works in read-only; themed panel and localized tooltip.
  - Message Details layout: Toggle left/right or top/bottom; preference saved in `localStorage`; updated resize handle and detail panel styling.

- Bug Fixes
  - Preserve selected message and scroll position when switching layouts.
  - Hide the detail panel when the selected message is filtered out.

<sup>Written for commit ba11b3d841872ebe0f1e605018fd2ff2e8859cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

