### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=law-chain-hot/websocket-devtools&type=Date)](https://www.star-history.com/#law-chain-hot/websocket-devtools&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=law-chain-hot/websocket-devtools&type=Date)](https://star-history.dera.page/#law-chain-hot/websocket-devtools&Date)
 
 ## ✨ Key Features
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it depended on the GitHub stargazer API, which has imposed restrictions that prevent the chart from loading. This change points the chart to star-history.dera.page, which uses an alternative data source that does not require an API token, so the chart renders correctly again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Star History chart in the README by switching from the restricted GitHub stargazer endpoint at `api.star-history.com` to `https://star-history.dera.page`, restoring rendering without an API token. Updates both the image source and the anchor link; no code or build changes.

<sup>Written for commit 57828b0dd4c373117bc56af48808afc378630602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

