### PR TITLE
fix(build): remove invalid popup icon import

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.6-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_ja.md
+++ b/README_ja.md
@@ -136,7 +136,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.6-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -131,7 +131,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.6-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -136,7 +136,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.6-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-devtools",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Professional debugging tool with real-time monitoring, message simulation, and traffic interception for developers",
   "type": "module",
   "main": "index.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebSocket DevTools",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Professional WebSocket debugging tool with message proxying, simulation, blocking and favorites features",
   "author": "Brian Luo",
   "homepage_url": "https://github.com/law-chain-hot/websocket-devtools",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import i18n, { t, initForPopup } from "../utils/i18n.js";
-import { Settings, Zap, Activity, Power, Wifi, MonitorSpeaker, Proxy, MessageCircle, Send, Ban, SquareActivity, Home, Heart, Github } from "lucide-react";
+import { Settings, Zap, Activity, Power, Wifi, MonitorSpeaker, MessageCircle, Send, Ban, SquareActivity, Home, Heart, Github } from "lucide-react";
 
 const Popup = () => {
   const [isEnabled, setIsEnabled] = useState(true);
@@ -202,7 +202,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.0.6</span>
+        <span style={styles.versionText}>v1.0.7</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/test/popupImports.test.js
+++ b/test/popupImports.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import * as lucideIcons from "lucide-react";
+
+test("popup only imports icons exported by lucide-react", async () => {
+  const popupSource = await readFile(
+    new URL("../src/popup/popup.jsx", import.meta.url),
+    "utf8",
+  );
+  const lucideImport = popupSource.match(
+    /import\s*{([^}]+)}\s*from\s*["']lucide-react["'];/,
+  );
+
+  assert.ok(lucideImport, "popup should import its icons from lucide-react");
+
+  const importedIcons = lucideImport[1]
+    .split(",")
+    .map((iconName) => iconName.trim().split(/\s+as\s+/)[0]);
+
+  for (const iconName of importedIcons) {
+    assert.ok(
+      Object.hasOwn(lucideIcons, iconName),
+      `lucide-react does not export ${iconName}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- remove the unused `Proxy` icon import that is not exported by `lucide-react`
- add a regression test for popup icon imports
- bump the extension version to 1.0.7

## Testing
- `pnpm test` (4 tests)
- `pnpm build`

The existing bundle-size warning remains unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an invalid `Proxy` icon import from the popup and adds a regression test to ensure only icons exported by `lucide-react` are imported. This prevents build breakage and future regressions; UI behavior is unchanged except the displayed version now shows 1.0.7, and the existing bundle-size warning remains.

<sup>Written for commit d1f30ef921fc9046d260133f594435d66a76c5b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

