### PR TITLE
fix(runtime): report page callback errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.8-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_ja.md
+++ b/README_ja.md
@@ -136,7 +136,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.8-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -131,7 +131,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.8-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -136,7 +136,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.7-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.8-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-devtools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Professional debugging tool with real-time monitoring, message simulation, and traffic interception for developers",
   "type": "module",
   "main": "index.js",

--- a/src/content/injected.js
+++ b/src/content/injected.js
@@ -18,6 +18,18 @@
   let connectionIdCounter = 0;
   const connections = new Map();
 
+  // Match native event dispatch: surface callback errors without stopping later listeners.
+  function reportUserCallbackError(error) {
+    if (typeof window.reportError === "function") {
+      window.reportError(error);
+      return;
+    }
+
+    queueMicrotask(() => {
+      throw error;
+    });
+  }
+
   // Binary Detection and Decoding Utilities
   function isBinaryData(data) {
     try {
@@ -587,6 +599,7 @@
             try {
               connectionInfo.userOnMessage.call(ws, simulatedEvent);
             } catch (error) {
+              reportUserCallbackError(error);
             }
           }
           
@@ -594,6 +607,7 @@
             try {
               listener.call(ws, simulatedEvent);
             } catch (error) {
+              reportUserCallbackError(error);
             }
           });
           
@@ -653,6 +667,7 @@
               try {
                 ws.onclose.call(ws, closeEvent);
               } catch (error) {
+                reportUserCallbackError(error);
               }
             }
 
@@ -710,6 +725,7 @@
             try {
               ws.onclose.call(ws, closeEvent);
             } catch (error) {
+              reportUserCallbackError(error);
             }
           }
 
@@ -753,6 +769,7 @@
             try {
               ws.onerror.call(ws, errorEvent);
             } catch (error) {
+              reportUserCallbackError(error);
             }
           }
 
@@ -835,6 +852,7 @@
           try {
             connectionInfo.userOnMessage.call(ws, event);
           } catch (error) {
+            reportUserCallbackError(error);
           }
         }
         
@@ -842,6 +860,7 @@
           try {
             listener.call(ws, event);
           } catch (error) {
+            reportUserCallbackError(error);
           }
         });
         
@@ -904,6 +923,7 @@
         try {
           connectionInfo.userOnMessage.call(ws, event);
         } catch (error) {
+          reportUserCallbackError(error);
         }
       }
       
@@ -911,6 +931,7 @@
         try {
           listener.call(ws, event);
         } catch (error) {
+          reportUserCallbackError(error);
         }
       });
     };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebSocket DevTools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Professional WebSocket debugging tool with message proxying, simulation, blocking and favorites features",
   "author": "Brian Luo",
   "homepage_url": "https://github.com/law-chain-hot/websocket-devtools",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -202,7 +202,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.0.7</span>
+        <span style={styles.versionText}>v1.0.8</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/test/injectedCallbackErrors.test.js
+++ b/test/injectedCallbackErrors.test.js
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  constructor(url) {
+    this.url = url;
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      listeners.filter((candidate) => candidate !== listener),
+    );
+  }
+
+  send() {}
+
+  close() {}
+
+  emit(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener.call(this, event);
+    }
+  }
+}
+
+async function loadInjectedScript({ supportReportError = true } = {}) {
+  const injectedSource = await readFile(
+    new URL("../src/content/injected.js", import.meta.url),
+    "utf8",
+  );
+  const reportedErrors = [];
+  const queuedMicrotasks = [];
+  const windowListeners = new Map();
+  const fakeWindow = {
+    WebSocket: FakeWebSocket,
+    location: {
+      href: "https://example.com/app",
+    },
+    addEventListener(type, listener) {
+      const listeners = windowListeners.get(type) ?? [];
+      listeners.push(listener);
+      windowListeners.set(type, listeners);
+    },
+    postMessage() {},
+  };
+  if (supportReportError) {
+    fakeWindow.reportError = (error) => {
+      reportedErrors.push(error);
+    };
+  }
+  fakeWindow.top = fakeWindow;
+
+  const context = vm.createContext({
+    ArrayBuffer,
+    Blob,
+    Date,
+    JSON,
+    Map,
+    Math,
+    TextDecoder,
+    URL,
+    Uint8Array,
+    atob,
+    btoa,
+    clearInterval() {},
+    clearTimeout() {},
+    console,
+    history: {
+      pushState() {},
+      replaceState() {},
+    },
+    queueMicrotask(callback) {
+      queuedMicrotasks.push(callback);
+    },
+    setInterval() {
+      return 1;
+    },
+    setTimeout() {
+      return 1;
+    },
+    window: fakeWindow,
+  });
+
+  vm.runInContext(injectedSource, context);
+
+  return { fakeWindow, queuedMicrotasks, reportedErrors };
+}
+
+function registerThrowingCallbacks(fakeWindow) {
+  const socket = new fakeWindow.WebSocket("wss://example.com/socket");
+  const callbackError = new Error("subscription callback failed");
+  let laterListenerRan = false;
+
+  socket.onmessage = () => {
+    throw callbackError;
+  };
+  socket.addEventListener("message", () => {
+    laterListenerRan = true;
+  });
+
+  socket.emit("message", { data: "payload" });
+
+  return { callbackError, laterListenerRan };
+}
+
+test("reports page callback errors without interrupting later message listeners", async () => {
+  const { fakeWindow, reportedErrors } = await loadInjectedScript();
+  const { callbackError, laterListenerRan } = registerThrowingCallbacks(fakeWindow);
+
+  assert.deepEqual(reportedErrors, [callbackError]);
+  assert.equal(laterListenerRan, true);
+});
+
+test("falls back to an asynchronous uncaught error when reportError is unavailable", async () => {
+  const { fakeWindow, queuedMicrotasks } = await loadInjectedScript({
+    supportReportError: false,
+  });
+  const { callbackError, laterListenerRan } = registerThrowingCallbacks(fakeWindow);
+
+  assert.equal(queuedMicrotasks.length, 1);
+  assert.throws(queuedMicrotasks[0], (error) => error === callbackError);
+  assert.equal(laterListenerRan, true);
+});


### PR DESCRIPTION
## Summary
- surface exceptions thrown by page WebSocket callbacks
- keep listener isolation so one failing handler does not block later listeners
- add regression coverage and bump to 1.0.8

## Testing
- `pnpm test` (6 tests)
- `pnpm build`

Fixes #27

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface errors thrown by page WebSocket callbacks instead of silently swallowing them, while keeping listener isolation so one failing handler doesn't block later listeners. Fixes #27.

**Bug Fixes**
- Callback errors now go through `window.reportError` where available, falling back to an asynchronous uncaught throw.
- Added regression coverage for error reporting and listener isolation.

<sup>Written for commit a1c59e79f39f1777c49737430031d89f4d91db7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

