### PR TITLE
docs: add manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 2. Click **"Get"** and confirm installation
 3. Open DevTools (F12) → **"WebSocket DevTools"** tab
 
+### Manual installation from GitHub
+1. Download the ZIP attached to the [latest GitHub Release](https://github.com/law-chain-hot/websocket-devtools/releases/latest)
+2. Extract the ZIP
+3. Open `chrome://extensions` or `edge://extensions`
+4. Enable **Developer mode**, choose **Load unpacked**, and select the extracted folder
+
+> Manual installations do not update automatically. Check the Releases page for newer versions.
+
 ### Homepage
 
 - 🌐 [WebSocket DevTools](https://websocket-devtools.com) - Official website with documentation and demos 

--- a/README_ja.md
+++ b/README_ja.md
@@ -40,6 +40,14 @@
 2. **「入手」**をクリックしてインストールを確認
 3. DevTools (F12) を開く → **「WebSocket DevTools」**タブ
 
+### GitHubから手動でインストール
+1. [最新のGitHub Release](https://github.com/law-chain-hot/websocket-devtools/releases/latest)に添付されたZIPファイルをダウンロード
+2. ZIPファイルを展開
+3. `chrome://extensions` または `edge://extensions` を開く
+4. **デベロッパーモード**を有効にし、**パッケージ化されていない拡張機能を読み込む**を選んで展開したフォルダーを指定
+
+> 手動インストールは自動更新されません。新しいバージョンはReleasesページで確認してください。
+
 ### ホームページ
 
 - 🌐 [WebSocket DevTools](https://websocket-devtools.com) - 公式ウェブサイト（ドキュメントとデモ付き）

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -40,6 +40,14 @@
 2. 点击 **"获取"** 并确认安装
 3. 打开开发者工具 (F12) → **"WebSocket DevTools"** 标签页
 
+### 从 GitHub 手动安装
+1. 下载[最新 GitHub Release](https://github.com/law-chain-hot/websocket-devtools/releases/latest)中附带的 ZIP 文件
+2. 解压 ZIP 文件
+3. 打开 `chrome://extensions` 或 `edge://extensions`
+4. 开启**开发者模式**，选择**加载已解压的扩展程序**，然后选中解压后的文件夹
+
+> 手动安装不会自动更新，请通过 Releases 页面获取新版本。
+
 ### 官网
 
 - 🌐 [WebSocket DevTools](https://websocket-devtools.com) - 官方网站

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -40,6 +40,14 @@
 2. 點擊 **"取得"** 並確認安裝
 3. 開啟開發者工具 (F12) → **"WebSocket DevTools"** 分頁
 
+### 從 GitHub 手動安裝
+1. 下載[最新 GitHub Release](https://github.com/law-chain-hot/websocket-devtools/releases/latest)中附帶的 ZIP 檔案
+2. 解壓縮 ZIP 檔案
+3. 開啟 `chrome://extensions` 或 `edge://extensions`
+4. 開啟**開發人員模式**，選擇**載入未封裝項目**，然後選取解壓縮後的資料夾
+
+> 手動安裝不會自動更新，請透過 Releases 頁面取得新版本。
+
 ### 官網
 
 - 🌐 [WebSocket DevTools](https://websocket-devtools.com) - 官方網站


### PR DESCRIPTION
## Summary
- document manual installation from the latest GitHub Release
- cover both Chrome and Edge extension pages
- keep English, Simplified Chinese, Traditional Chinese, and Japanese READMEs aligned
- note that manual installations do not update automatically

## Verification
- latest Release link returns HTTP 200
- `pnpm test` (10 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual installation instructions for the latest GitHub Release across all four README languages. Covers loading the unpacked extension in Chrome and Edge, and notes that manual installs do not update automatically.

<sup>Written for commit 62f54e18ee687c0d7905fc174df66ee94e8e5fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

