### PR TITLE
chore(branding): align extension action title

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.9-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_ja.md
+++ b/README_ja.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.9-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -139,7 +139,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.9-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.9-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-devtools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Professional debugging tool with real-time monitoring, message simulation, and traffic interception for developers",
   "type": "module",
   "main": "index.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebSocket DevTools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Professional WebSocket debugging tool with message proxying, simulation, blocking and favorites features",
   "author": "Brian Luo",
   "homepage_url": "https://github.com/law-chain-hot/websocket-devtools",
@@ -45,7 +45,7 @@
   ],
 
   "action": {
-    "default_title": "WebSocket Proxy Pro - Monitor & Debug WebSocket Connections",
+    "default_title": "WebSocket DevTools - Monitor & Debug WebSocket Connections",
     "default_popup": "src/popup/popup.html",
     "default_icon": {
       "16": "icons/icon-small.png",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -202,7 +202,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.0.9</span>
+        <span style={styles.versionText}>v1.0.10</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/test/manifestMetadata.test.js
+++ b/test/manifestMetadata.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("keeps the action tooltip aligned with the extension name", async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL("../src/manifest.json", import.meta.url), "utf8"),
+  );
+
+  assert.ok(
+    manifest.action.default_title.startsWith(manifest.name),
+    `Expected action title to start with ${JSON.stringify(manifest.name)}`,
+  );
+});


### PR DESCRIPTION
## Summary
- replace the stale WebSocket Proxy Pro action tooltip with WebSocket DevTools
- add a manifest metadata consistency test
- bump the extension to 1.0.10

## Verification
- `pnpm test` (11 tests)
- `pnpm build`
- Edge 152 unpacked-extension WebSocket smoke test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the stale WebSocket Proxy Pro action tooltip with WebSocket DevTools so the extension's branding is consistent, and adds a test to keep it that way.

- Adds a manifest metadata test asserting the action title starts with the extension name.
- Bumps the extension to 1.0.10 across `manifest.json`, `package.json`, the popup footer, and README badges.

<sup>Written for commit bb4f77cc61fd62853cb8de96ac3b1f553f749b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

