### PR TITLE
fix: prevent client close from staying pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_ja.md
+++ b/README_ja.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -139,7 +139,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.10-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-devtools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Professional debugging tool with real-time monitoring, message simulation, and traffic interception for developers",
   "type": "module",
   "main": "index.js",

--- a/src/content/injected.js
+++ b/src/content/injected.js
@@ -619,6 +619,12 @@
     }
   }
 
+  function clearClientCloseFallback(connectionInfo) {
+    if (!connectionInfo.closeFallbackTimer) return;
+    clearTimeout(connectionInfo.closeFallbackTimer);
+    connectionInfo.closeFallbackTimer = null;
+  }
+
   // Handle simulated system event
   function handleSimulateSystemEvent(connectionId, eventData) {
 
@@ -693,39 +699,41 @@
           }
           
           connectionInfo.isSimulatingClose = true; // Set flag
-          connectionInfo.closeFallbackTimer = setTimeout(() => {
-            connectionInfo.closeFallbackTimer = null;
-            if (connectionInfo.status === "closed") return;
-
-            connectionInfo.status = "closed";
-            connectionInfo.isSimulatingClose = false;
-            connectionInfo.closeEventReported = true;
-            sendEvent({
-              id: connectionId,
-              url: connectionInfo.url,
-              type: "close",
-              data: `Client Close Timeout: Code: ${requestedCode}, Reason: ${requestedReason}`,
-              direction: "system",
-              timestamp: Date.now(),
-              status: "closed",
-              simulated: true,
-              systemEventType: "client-close",
-              messageId: generateMessageId(),
-            }, true);
-            connections.delete(connectionId);
-          }, CLIENT_CLOSE_FALLBACK_MS);
-          
           try {
             // Call original WebSocket's close method
             // This will trigger the native WebSocket close handshake, and the browser will naturally emit a 'close' event,
             // which our proxy's 'close' event listener will capture and process.
             connectionInfo.originalClose.call(ws, requestedCode, requestedReason);
+            connectionInfo.status = "closing";
+            connectionInfo.closeFallbackTimer = setTimeout(() => {
+              connectionInfo.closeFallbackTimer = null;
+              if (connectionInfo.status !== "closing") return;
+
+              connectionInfo.status = "closed";
+              connectionInfo.isSimulatingClose = false;
+              connectionInfo.closeEventReported = true;
+              sendEvent({
+                id: connectionId,
+                url: connectionInfo.url,
+                type: "close",
+                data: `Client Close Timeout: Code: ${requestedCode}, Reason: ${requestedReason}`,
+                direction: "system",
+                timestamp: Date.now(),
+                status: "closed",
+                simulated: true,
+                systemEventType: "client-close",
+                messageId: generateMessageId(),
+              }, true);
+              connections.delete(connectionId);
+            }, CLIENT_CLOSE_FALLBACK_MS);
           } catch (error) {
+            connectionInfo.isSimulatingClose = false;
           }
 
           break;
 
         case "server-close":
+          clearClientCloseFallback(connectionInfo);
           
           // Create simulated CloseEvent
           const closeEvent = new CloseEvent("close", {
@@ -770,6 +778,7 @@
 
         case "client-error":
         case "server-error":
+          clearClientCloseFallback(connectionInfo);
           
           // Create simulated ErrorEvent
           const errorEvent = new ErrorEvent("error", {
@@ -1060,10 +1069,7 @@
     ["open", "close", "error"].forEach((eventType) => {
       connectionInfo.originalAddEventListener(eventType, (event) => {
 
-        if (eventType === "close" && connectionInfo.closeFallbackTimer) {
-          clearTimeout(connectionInfo.closeFallbackTimer);
-          connectionInfo.closeFallbackTimer = null;
-        }
+        if (eventType === "close") clearClientCloseFallback(connectionInfo);
         if (eventType === "close" && connectionInfo.closeEventReported) {
           return;
         }

--- a/src/content/injected.js
+++ b/src/content/injected.js
@@ -17,6 +17,7 @@
 
   let connectionIdCounter = 0;
   const connections = new Map();
+  const CLIENT_CLOSE_FALLBACK_MS = 5000;
 
   // Match native event dispatch: surface callback errors without stopping later listeners.
   function reportUserCallbackError(error) {
@@ -495,8 +496,8 @@
   }
 
   // Send event to content script (buffered)
-  function sendEvent(eventData) {
-    if(!proxyState.isMonitoring){
+  function sendEvent(eventData, force = false) {
+    if(!proxyState.isMonitoring && !force){
       return;
     }
 
@@ -672,6 +673,7 @@
             }
 
             // Send system event to extension
+            connectionInfo.closeEventReported = true;
             sendEvent({
               id: connectionId,
               url: connectionInfo.url,
@@ -683,7 +685,7 @@
               simulated: true,
               systemEventType: "client-close", // Keep original intention
               messageId: generateMessageId(),
-            });
+            }, true);
 
             // Clean up connection
             connections.delete(connectionId);
@@ -691,6 +693,27 @@
           }
           
           connectionInfo.isSimulatingClose = true; // Set flag
+          connectionInfo.closeFallbackTimer = setTimeout(() => {
+            connectionInfo.closeFallbackTimer = null;
+            if (connectionInfo.status === "closed") return;
+
+            connectionInfo.status = "closed";
+            connectionInfo.isSimulatingClose = false;
+            connectionInfo.closeEventReported = true;
+            sendEvent({
+              id: connectionId,
+              url: connectionInfo.url,
+              type: "close",
+              data: `Client Close Timeout: Code: ${requestedCode}, Reason: ${requestedReason}`,
+              direction: "system",
+              timestamp: Date.now(),
+              status: "closed",
+              simulated: true,
+              systemEventType: "client-close",
+              messageId: generateMessageId(),
+            }, true);
+            connections.delete(connectionId);
+          }, CLIENT_CLOSE_FALLBACK_MS);
           
           try {
             // Call original WebSocket's close method
@@ -824,6 +847,8 @@
       messageQueue: [], // Message queue during pause
       blockedMessages: [], // Blocked messages
       isSimulatingClose: false, // New: for marking if client-initiated close is being simulated
+      closeFallbackTimer: null,
+      closeEventReported: false,
     };
 
     connections.set(connectionId, connectionInfo);
@@ -1035,6 +1060,15 @@
     ["open", "close", "error"].forEach((eventType) => {
       connectionInfo.originalAddEventListener(eventType, (event) => {
 
+        if (eventType === "close" && connectionInfo.closeFallbackTimer) {
+          clearTimeout(connectionInfo.closeFallbackTimer);
+          connectionInfo.closeFallbackTimer = null;
+        }
+        if (eventType === "close" && connectionInfo.closeEventReported) {
+          return;
+        }
+        const forceEvent = eventType === "close" && connectionInfo.isSimulatingClose;
+
         // Update connection status
         if (eventType === "open") {
           connectionInfo.status = "open";
@@ -1085,7 +1119,10 @@
             }
         }
         
-        sendEvent(payload);
+        if (eventType === "close") {
+          connectionInfo.closeEventReported = true;
+        }
+        sendEvent(payload, forceEvent);
 
         if (eventType === "close") {
           connections.delete(connectionId);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebSocket DevTools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Professional WebSocket debugging tool with message proxying, simulation, blocking and favorites features",
   "author": "Brian Luo",
   "homepage_url": "https://github.com/law-chain-hot/websocket-devtools",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -202,7 +202,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.0.10</span>
+        <span style={styles.versionText}>v1.0.11</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/test/closeConnection.test.js
+++ b/test/closeConnection.test.js
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+class FakeClock {
+  constructor() {
+    this.now = 0;
+    this.nextId = 1;
+    this.tasks = new Map();
+  }
+
+  setTimeout(callback, delay = 0) {
+    const id = this.nextId++;
+    this.tasks.set(id, { callback, dueAt: this.now + delay });
+    return id;
+  }
+
+  clearTimeout(id) {
+    this.tasks.delete(id);
+  }
+
+  runUntil(targetTime) {
+    while (true) {
+      const next = [...this.tasks.entries()]
+        .filter(([, task]) => task.dueAt <= targetTime)
+        .sort((left, right) => left[1].dueAt - right[1].dueAt)[0];
+      if (!next) break;
+
+      const [id, task] = next;
+      this.tasks.delete(id);
+      this.now = task.dueAt;
+      task.callback();
+    }
+    this.now = targetTime;
+  }
+}
+
+class NonResponsiveWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = NonResponsiveWebSocket.CONNECTING;
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    this.listeners.set(type, listeners.filter((candidate) => candidate !== listener));
+  }
+
+  send() {}
+
+  close() {
+    this.readyState = NonResponsiveWebSocket.CLOSING;
+  }
+
+  emit(type, event = {}) {
+    if (type === "open") this.readyState = NonResponsiveWebSocket.OPEN;
+    if (type === "close") this.readyState = NonResponsiveWebSocket.CLOSED;
+    for (const listener of this.listeners.get(type) ?? []) listener.call(this, event);
+  }
+}
+
+async function createHarness() {
+  const injectedSource = await readFile(
+    new URL("../src/content/injected.js", import.meta.url),
+    "utf8",
+  );
+  const clock = new FakeClock();
+  const postedMessages = [];
+  const windowListeners = new Map();
+  const fakeWindow = {
+    WebSocket: NonResponsiveWebSocket,
+    location: { href: "https://example.com/app" },
+    addEventListener(type, listener) {
+      const listeners = windowListeners.get(type) ?? [];
+      listeners.push(listener);
+      windowListeners.set(type, listeners);
+    },
+    postMessage(message) {
+      postedMessages.push(message);
+    },
+  };
+  fakeWindow.top = fakeWindow;
+
+  vm.runInContext(
+    injectedSource,
+    vm.createContext({
+      ArrayBuffer,
+      Blob,
+      CloseEvent: class CloseEvent {},
+      Date,
+      JSON,
+      Map,
+      Math,
+      MessageEvent: class MessageEvent {},
+      TextDecoder,
+      URL,
+      Uint8Array,
+      atob,
+      btoa,
+      clearInterval() {},
+      clearTimeout: clock.clearTimeout.bind(clock),
+      console,
+      history: { pushState() {}, replaceState() {} },
+      queueMicrotask,
+      setInterval() {
+        return 1;
+      },
+      setTimeout: clock.setTimeout.bind(clock),
+      window: fakeWindow,
+    }),
+  );
+
+  return {
+    clock,
+    fakeWindow,
+    postedMessages,
+    sendControlMessage(data) {
+      for (const listener of windowListeners.get("message") ?? []) {
+        listener({ data });
+      }
+    },
+  };
+}
+
+test("finishes a client close when the peer never completes the handshake", async () => {
+  const harness = await createHarness();
+  const socket = new harness.fakeWindow.WebSocket("wss://example.com/socket");
+  socket.emit("open");
+  harness.clock.runUntil(100);
+  harness.postedMessages.length = 0;
+
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "simulate-system-event",
+    connectionId: socket._connectionId,
+    eventType: "client-close",
+    code: 1000,
+    reason: "Closed by user",
+  });
+  harness.clock.runUntil(10_000);
+
+  const closeEvents = harness.postedMessages
+    .filter((message) => message.type === "websocket-event-batch")
+    .flatMap((message) => message.payload)
+    .filter((event) => event.id === socket._connectionId && event.type === "close");
+
+  assert.equal(socket.readyState, NonResponsiveWebSocket.CLOSING);
+  assert.equal(closeEvents.length, 1);
+  assert.equal(closeEvents[0].status, "closed");
+  assert.equal(closeEvents[0].simulated, true);
+  assert.equal(closeEvents[0].systemEventType, "client-close");
+
+  socket.emit("close", { code: 1000, reason: "Closed by user" });
+  harness.clock.runUntil(10_100);
+  const closeEventsAfterNativeClose = harness.postedMessages
+    .filter((message) => message.type === "websocket-event-batch")
+    .flatMap((message) => message.payload)
+    .filter((event) => event.id === socket._connectionId && event.type === "close");
+  assert.equal(closeEventsAfterNativeClose.length, 1);
+});
+
+test("reports a requested client close while monitoring is stopped", async () => {
+  const harness = await createHarness();
+  const socket = new harness.fakeWindow.WebSocket("wss://example.com/socket");
+  socket.emit("open");
+  harness.clock.runUntil(100);
+  harness.postedMessages.length = 0;
+
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "stop-monitoring",
+  });
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "simulate-system-event",
+    connectionId: socket._connectionId,
+    eventType: "client-close",
+    code: 1000,
+    reason: "Closed by user",
+  });
+  socket.emit("close", { code: 1000, reason: "Closed by user" });
+  harness.clock.runUntil(1_000);
+
+  const closeEvents = harness.postedMessages
+    .filter((message) => message.type === "websocket-event-batch")
+    .flatMap((message) => message.payload)
+    .filter((event) => event.id === socket._connectionId && event.type === "close");
+  assert.equal(closeEvents.length, 1);
+  assert.equal(closeEvents[0].status, "closed");
+});

--- a/test/closeConnection.test.js
+++ b/test/closeConnection.test.js
@@ -61,7 +61,10 @@ class NonResponsiveWebSocket {
 
   send() {}
 
-  close() {
+  close(_code, reason = "") {
+    if (Buffer.byteLength(reason, "utf8") > 123) {
+      throw new SyntaxError("Close reason exceeds 123 bytes");
+    }
     this.readyState = NonResponsiveWebSocket.CLOSING;
   }
 
@@ -99,11 +102,22 @@ async function createHarness() {
     vm.createContext({
       ArrayBuffer,
       Blob,
-      CloseEvent: class CloseEvent {},
+      CloseEvent: class CloseEvent {
+        constructor(type, details = {}) {
+          this.type = type;
+          Object.assign(this, details);
+        }
+      },
       Date,
       JSON,
       Map,
       Math,
+      ErrorEvent: class ErrorEvent {
+        constructor(type, details = {}) {
+          this.type = type;
+          Object.assign(this, details);
+        }
+      },
       MessageEvent: class MessageEvent {},
       TextDecoder,
       URL,
@@ -200,4 +214,62 @@ test("reports a requested client close while monitoring is stopped", async () =>
     .filter((event) => event.id === socket._connectionId && event.type === "close");
   assert.equal(closeEvents.length, 1);
   assert.equal(closeEvents[0].status, "closed");
+});
+
+test("keeps the connection open when the native close request is rejected", async () => {
+  const harness = await createHarness();
+  const socket = new harness.fakeWindow.WebSocket("wss://example.com/socket");
+  socket.emit("open");
+  harness.clock.runUntil(100);
+  harness.postedMessages.length = 0;
+
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "simulate-system-event",
+    connectionId: socket._connectionId,
+    eventType: "client-close",
+    code: 1000,
+    reason: "x".repeat(124),
+  });
+  harness.clock.runUntil(10_000);
+
+  const closeEvents = harness.postedMessages
+    .filter((message) => message.type === "websocket-event-batch")
+    .flatMap((message) => message.payload)
+    .filter((event) => event.id === socket._connectionId && event.type === "close");
+  assert.equal(socket.readyState, NonResponsiveWebSocket.OPEN);
+  assert.equal(closeEvents.length, 0);
+});
+
+test("does not report a close timeout after the connection reaches an error state", async () => {
+  const harness = await createHarness();
+  const socket = new harness.fakeWindow.WebSocket("wss://example.com/socket");
+  socket.emit("open");
+  harness.clock.runUntil(100);
+  harness.postedMessages.length = 0;
+
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "simulate-system-event",
+    connectionId: socket._connectionId,
+    eventType: "client-close",
+    code: 1000,
+    reason: "Closed by user",
+  });
+  harness.sendControlMessage({
+    source: "websocket-proxy-content",
+    type: "simulate-system-event",
+    connectionId: socket._connectionId,
+    eventType: "server-error",
+    code: "EUNEXPECTED",
+    message: "Connection failed while closing",
+  });
+  harness.clock.runUntil(10_000);
+
+  const events = harness.postedMessages
+    .filter((message) => message.type === "websocket-event-batch")
+    .flatMap((message) => message.payload)
+    .filter((event) => event.id === socket._connectionId);
+  assert.equal(events.filter((event) => event.type === "error").length, 1);
+  assert.equal(events.filter((event) => event.type === "close").length, 0);
 });


### PR DESCRIPTION
修复点击关闭后连接一直停在“关闭中”的问题。

- 对端不完成关闭握手时，5 秒后结束本地关闭状态
- 暂停监控时仍会上报用户主动关闭结果
- 避免迟到的原生 close 事件重复记录
- 增加对应回归测试

Fixes #39

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user-initiated WebSocket closes getting stuck in "closing" when the peer never completes the close handshake. The local connection now finalizes after 5 seconds and reports a simulated close event, even when monitoring is paused.

- Adds a 5-second fallback timer that emits a simulated close event and cleans up the connection when the peer stays silent.
- Reports user-initiated close results while monitoring is paused, and ignores late native `close` events after the fallback has reported.
- Skips the fallback when the native close call is rejected or the connection reaches an error state.
- Adds regression tests for stall, paused-monitoring, rejected-close, and error-state cases.
- Bumps extension and package versions to 1.0.11.

Fixes #39.

<sup>Written for commit 8ef25347b504ab21d5766161d445f03546f17108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/law-chain-hot/websocket-devtools/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

