### PR TITLE
chore: prepare v1.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Complete WebSocket Traffic Control with advanced proxy, simulation, and blocking
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.2.0-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_ja.md
+++ b/README_ja.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.2.0-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -139,7 +139,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.2.0-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -144,7 +144,7 @@
 
 </div> 
 
-[version-shield]: https://img.shields.io/badge/version-1.0.11-55b467?labelColor=black&logo=github&style=flat-square
+[version-shield]: https://img.shields.io/badge/version-1.2.0-55b467?labelColor=black&logo=github&style=flat-square
 [license-shield]: https://img.shields.io/badge/license-MIT-369eff?labelColor=black&logo=opensourceinitiative&style=flat-square
 [chrome-shield]: https://img.shields.io/badge/Chrome%20Web%20Store-Install-ffcb47?labelColor=black&logo=googlechrome&logoColor=white&style=flat-square
 [privacy-shield]: https://img.shields.io/badge/privacy-local%20only-c4f042?labelColor=black&logo=shield-check&style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-devtools",
-  "version": "1.0.11",
+  "version": "1.2.0",
   "description": "Professional debugging tool with real-time monitoring, message simulation, and traffic interception for developers",
   "type": "module",
   "main": "index.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebSocket DevTools",
-  "version": "1.0.11",
+  "version": "1.2.0",
   "description": "Professional WebSocket debugging tool with message proxying, simulation, blocking and favorites features",
   "author": "Brian Luo",
   "homepage_url": "https://github.com/law-chain-hot/websocket-devtools",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -3,6 +3,8 @@ import { createRoot } from "react-dom/client";
 import i18n, { t, initForPopup } from "../utils/i18n.js";
 import { Settings, Zap, Activity, Power, Wifi, MonitorSpeaker, MessageCircle, Send, Ban, SquareActivity, Home, Heart, Github } from "lucide-react";
 
+const extensionVersion = chrome.runtime.getManifest().version;
+
 const Popup = () => {
   const [isEnabled, setIsEnabled] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
@@ -202,7 +204,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.2.0</span>
+        <span style={styles.versionText}>v{extensionVersion}</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -202,7 +202,7 @@ const Popup = () => {
 
       {/* Footer */}
       <div style={styles.footer}>
-        <span style={styles.versionText}>v1.0.11</span>
+        <span style={styles.versionText}>v1.2.0</span>
         <div style={styles.footerIcons}>
 
           <div className="tooltip-container">

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,6 @@ export default defineConfig(({ mode }) => ({
     react(),
     webExtension({
       manifest: "./src/manifest.json",
-      skipManifestValidation: true,
       watchFilePaths: ["src/**/*"],
       additionalInputs: [
         "src/content/injected.js",

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => ({
     react(),
     webExtension({
       manifest: "./src/manifest.json",
+      skipManifestValidation: true,
       watchFilePaths: ["src/**/*"],
       additionalInputs: [
         "src/content/injected.js",


### PR DESCRIPTION
将公开维护版本升级到 1.2 系列。

- 统一 package、manifest 和 README 版本为 1.2.0
- Popup 直接读取 manifest 版本，避免以后漏改
- 公开构建继续保留完整 manifest schema 校验

发布时的 TLS 瞬断重试仅保存在本地私有 SOP，不进入公开仓库。